### PR TITLE
fix componet and devcontainer json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,9 @@
     "name": "Rust Template",
     // Update the 'dockerComposeFile' list if you have more compose files or use different names.
     // The .devcontainer/docker-compose.yml file contains any overrides you need/want to make.
-    "dockerComposeFile": ["../docker-compose.yml"],
+    "dockerComposeFile": [
+        "../docker-compose.yml"
+    ],
     // The 'service' property is the name of the service for the container that VS Code should
     // use. Update this value and .devcontainer/docker-compose.yml to the real service name.
     "service": "rust",
@@ -17,7 +19,7 @@
     // Add the IDs of extensions you want installed when the container is created.
     "extensions": [
         "editorconfig.editorconfig",
-        "matklad.rust-analyzer",
+        "rust-lang.rust-analyzer",
         "vadimcn.vscode-lldb",
         "bungcip.better-toml",
         "serayuzgur.crates"

--- a/docker/rust/Dockerfile
+++ b/docker/rust/Dockerfile
@@ -4,5 +4,8 @@ RUN apt-get update && \
     apt-get -y install git && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
-    rustup component add rls rust-analysis rust-src rustfmt clippy && \
-    cargo install cargo-edit cargo-watch
+    rustup component add rust-analyzer rust-src rustfmt clippy && \
+    cargo install cargo-edit cargo-watch && \
+    rustup target add wasm32-unknown-unknown && \
+    cargo install --locked trunk
+


### PR DESCRIPTION
### 修正内容
  - rlsのビルドエラーが発生するため、「rls、 rust-analysis」を削除し「rust-analyzer」を利用するようにする
  - matklad.rust-analyzerのネームスペース変更に伴い「rust-lang.rust-analyzer」を利用するように変更する